### PR TITLE
Add detailed GitHub Desktop tutorial for beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Visit [GitHub Desktop's website](https://desktop.github.com/) and click the _Dow
 ## 2. Installing the EBD-Toolkit Project
 In GitHub Desktop, choose _File > Clone repository... > URL_ and enter the following URL: `https://github.com/rabaur/EBD-Toolkit.git`. Below, you will see where the toolkit will be saved on your system. Then, click _clone_.
 After the download, you can verify that the project has been saved to the indicated path.
+
+Detailed instructions on how to use GitHub Desktop for this project can be found in [How to use GitHub Desktop](docs/using_github_desktop.md). 
 ## 3. Installing the Unity Hub
 Now that we have downloaded the project, we need to install Unity Engine to open and view it. Visit [Unity's website](https://unity.com/pricing), then choose _Student & hobbyist_ > _Personal_ > _1. Download the Unity Hub > Download for [Windows | Mac | Linux]_, depending on your platform.
 After opening Unity Hub, you will be prompted to sign in. Please create a Unity ID if you have not already done so.

--- a/docs/using_github_desktop.md
+++ b/docs/using_github_desktop.md
@@ -1,0 +1,28 @@
+# Using GitHub Desktop
+
+## 1. Download and install GitHub Desktop
+Download GitHub Desktop from the [official website](https://github.com/apps/desktop). Follow the installation instructions for your operating system (Windows or macOS).
+
+## 2. Clone the EBD-toolkit repository via GitHub Desktop
+The repository (terminology for "project" or "shared folder" in GitHub Desktop) that we need to clone can be found at the front page of the EBD-toolkit GitHub repository: https://github.com/rabaur/EBD-Toolkit. Find the link by clicking the green “Code” button, then copy URL to clipboard. A simplified tutorial can also be found on this page.
+
+![Image](https://github.com/user-attachments/assets/aab64f9b-94d0-4026-a4ff-95741fc380e1)
+
+Open Github Desktop and select File > Clone Repository. In the dialog that opens, select the URL tab and paste the URL you copied from the EBD-toolkit repository. Select a local path where you want to save the repository and click Clone. 
+
+![Image](https://github.com/user-attachments/assets/d8e0a49f-b08a-4f6a-bbf0-62d20a1f1c84)
+
+![Image](https://github.com/user-attachments/assets/52373f9d-8f2f-4f72-adb1-456f46504c32)
+
+>[!IMPORTANT]
+> Make sure that the path is not located within any cloud storage folder, such as OneDrive, Google Drive, or Dropbox. This can cause issues with file syncing and version control.
+
+Sometimes, there might be functional updates to the repository. The functionality to check the existence of updates is called "fetching". Upon opening the repository, GitHub Desktop will automatically "fetch" once to check for updates. You can also do this manually by clicking on the "Fetch origin" button in the top bar. Fetching will not change any files in your local repository. 
+
+![Image](https://github.com/user-attachments/assets/1b0f31eb-c1c0-4b73-a037-1e14c55e4ef9)
+
+After fetching, there might be two different scenarios:
+1. **No updates available**: If there are no updates, you will see a message indicating that your branch is up to date with the remote repository.
+2. **Updates available**: If there are updates, the "Fetch origin" button will change to "Pull origin". Click on this button to download the updates to your local repository. Pull means "to get the latest changes of the software, compare to my current version, and update my version if necessary". After pulling, remote updates are downloaded to your local computer, unless the user has also done local changes to the same files that were updated. 
+
+You might also see a "current branch" dropdown menu in the top bar. For most users, this will be set to "main". This is the default branch of the repository, and the functionalities in this branch are the most stable. Other branches might contain work-in-progress features or experimental changes, and might even be broken. If you are not sure which branch to use, stick to the "main" branch.

--- a/docs/using_github_desktop.md
+++ b/docs/using_github_desktop.md
@@ -6,13 +6,14 @@ Download GitHub Desktop from the [official website](https://github.com/apps/desk
 ## 2. Clone the EBD-toolkit repository via GitHub Desktop
 The repository (terminology for "project" or "shared folder" in GitHub Desktop) that we need to clone can be found at the front page of the EBD-toolkit GitHub repository: https://github.com/rabaur/EBD-Toolkit. Find the link by clicking the green “Code” button, then copy URL to clipboard. A simplified tutorial can also be found on this page.
 
-![Image](https://github.com/user-attachments/assets/aab64f9b-94d0-4026-a4ff-95741fc380e1)
+![image](https://github.com/user-attachments/assets/2302da01-0169-4d00-b9c0-62f0958ee87f)
+
 
 Open Github Desktop and select File > Clone Repository. In the dialog that opens, select the URL tab and paste the URL you copied from the EBD-toolkit repository. Select a local path where you want to save the repository and click Clone. 
 
-![Image](https://github.com/user-attachments/assets/d8e0a49f-b08a-4f6a-bbf0-62d20a1f1c84)
+![image](https://github.com/user-attachments/assets/8ee0487c-bfee-45db-b636-b1dd2fec7183)
 
-![Image](https://github.com/user-attachments/assets/52373f9d-8f2f-4f72-adb1-456f46504c32)
+![image](https://github.com/user-attachments/assets/8f8c0fcf-7a71-4eb5-9a26-8518b167fef2)
 
 >[!IMPORTANT]
 > Make sure that the path is not located within any cloud storage folder, such as OneDrive, Google Drive, or Dropbox. This can cause issues with file syncing and version control.


### PR DESCRIPTION
- Introduce a comprehensive guide on using GitHub Desktop, aimed at non-experienced users, to facilitate the cloning and management of the EBD-Toolkit project. 
- Update documentation to include this new tutorial.